### PR TITLE
Добавление метода для получения статуса платежа

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ $preauthorizeLink = $psb
     ->preauthorize($amount)
     ->getLink($expiresAt);
 ```
+To get payment status, use `getStatus` method after building client
+```
+$psb
+    ->customer($customerEmail)
+    ->order($orderId, "Order #{$orderId}")
+    ->preauthorize($amount)
+    ->getStatus();
+```
+
 To save card during the preauthorization process use `preauthorizeAndSaveCard` method: 
 ```php
 $psb

--- a/src/PsbClient.php
+++ b/src/PsbClient.php
@@ -389,6 +389,14 @@ class PsbClient
         return $response->ref;
     }
 
+    public function getStatus(): Payload
+    {
+        $this->fillConfigDefaults();
+        $this->signRequest();
+
+        return $this->doRequest('/cgi-bin/check_operation/ecomm_check');
+    }
+
     public function getForm(): string
     {
         $this->fillConfigDefaults();

--- a/tests/Unit/PsbClientTest.php
+++ b/tests/Unit/PsbClientTest.php
@@ -436,7 +436,6 @@ class PsbClientTest extends TestCase
 
     public function testGetStatus(): void
     {
-        $url = 'the-payment-lint';
         $amount = 123.45;
         $config = Config::fromArray(self::CONFIG_ARRAY);
         $timestamp = 'the-timestamp';
@@ -498,7 +497,6 @@ class PsbClientTest extends TestCase
 
     public function testGetStatusReturnsEmptyArray(): void
     {
-        $url = 'the-payment-lint';
         $amount = 123.45;
         $config = Config::fromArray(self::CONFIG_ARRAY);
         $timestamp = 'the-timestamp';


### PR DESCRIPTION
В документации появился метод для получения статуса платежа под пунктом 6 - "Сервис проверки статуса операции"
Метод возвращает Payload, у которого можно проверить статус операции